### PR TITLE
Enable the Haystack agent to run on Java >= 9

### DIFF
--- a/agent-dispatchers/kafka/pom.xml
+++ b/agent-dispatchers/kafka/pom.xml
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${project.jdk.version}</source>
                     <target>${project.jdk.version}</target>

--- a/agent-providers/span/pom.xml
+++ b/agent-providers/span/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${project.jdk.version}</source>
                     <target>${project.jdk.version}</target>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${project.jdk.version}</source>
                     <target>${project.jdk.version}</target>

--- a/bundlers/haystack-agent/pom.xml
+++ b/bundlers/haystack-agent/pom.xml
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${project.jdk.version}</source>
                     <target>${project.jdk.version}</target>

--- a/config-providers/file/pom.xml
+++ b/config-providers/file/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${project.jdk.version}</source>
                     <target>${project.jdk.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -73,16 +73,17 @@
         <commons-lang.version>3.4</commons-lang.version>
         <grpc.version>1.7.0</grpc.version>
         <metrics-core.version>3.2.5</metrics-core.version>
+        <jaxb.version>2.3.0</jaxb.version>
 
         <scala.major.version>2</scala.major.version>
-        <scala.minor.version>11</scala.minor.version>
-        <scala.tiny.version>8</scala.tiny.version>
+        <scala.minor.version>12</scala.minor.version>
+        <scala.tiny.version>6</scala.tiny.version>
         <scala.major.minor.version>${scala.major.version}.${scala.minor.version}</scala.major.minor.version>
         <scala-library.version>${scala.major.version}.${scala.minor.version}.${scala.tiny.version}</scala-library.version>
         <testng.version>6.8</testng.version>
         <pegdown.version>1.6.0</pegdown.version>
-        <scalatest.version>3.0.3</scalatest.version>
-        <easymock.version>3.4</easymock.version>
+        <scalatest.version>3.0.5</scalatest.version>
+        <easymock.version>3.6</easymock.version>
         <junit.version>4.12</junit.version>
 
         <aws-sdk.version>1.11.128</aws-sdk.version>
@@ -93,10 +94,10 @@
         <pmd.version>5.1.3</pmd.version>
         <pmd.ruleset.location>pmdrules/pmd-ruleset.xml</pmd.ruleset.location>
         <pmd.failOnViolation>true</pmd.failOnViolation>
-        <jacoco.version>0.7.9</jacoco.version>
+        <jacoco.version>0.8.1</jacoco.version>
 
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
@@ -217,6 +218,13 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
+        </dependency>
+
+        <!-- JAXB / Java annotations - required to run the agent on Java >= 9 -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
         </dependency>
 
         <!-- Test Dependencies  -->
@@ -342,7 +350,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <source>${project.jdk.version}</source>
                         <target>${project.jdk.version}</target>


### PR DESCRIPTION
List of updated dependencies:

Scala 2.11.8 -> 2.12.6
ScalaTest 3.0.3 -> 3.0.5
Easymock 3.4 -> 3.6
Jacoco 0.7.9 -> 0.8.1
Maven Javadoc Plugin 2.10.4 -> 3.0.1
Maven Compiler Plugin 3.6.1 -> 3.8.0

Added JaxB API 2.3.0 in the runtime dependencies list