### PR TITLE
Add http agent dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ agents {
         bootstrap.servers = kafka-svc:9092
         producer.topic = spans
       }
+      
+      http {
+        url = http://collector-svc:8080/spans
+        callTimeoutMillis = 500
+        connectionPool.maxIdleConnections = 5
+        connectionPool.keepAliveDurationMinutes = 5
+      }
     }
   }
 }
@@ -119,6 +126,17 @@ b. bootstrap.servers - set of bootstrap servers
 
 ```
 The Kafka dispatcher can be configured with other Kafka producer properties in the same way as bootstrap.servers.
+
+### HTTP Dispatcher
+The HTTP dispatcher uses an http client to post spans to a remote collector. 
+
+```
+a. url - url for the http span collector (eg: http://collector-svc:8080/spans)
+b. callTimeoutMillis - timeout in milliseconds for reporting spans to the collector. Defaults to 500 ms.
+b. connectionPool.maxIdleConnections - number of idle connections to keep in the connection pool. Defaults to 5
+b. connectionPool.keepAliveDurationMinutes - keep alive duration in minutes for connections in the connection pool. Defaults to 5.
+
+```
 
 ## How to build code?
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ agents {
       
       http {
         url = http://collector-svc:8080/spans
-        client.timeoutmillis = 500
-        client.connectionpool.idleconnections.max = 5
-        client.connectionpool.keepaliveminutes = 5
+        client.timeout.millis = 500
+        client.connectionpool.idle.max = 5
+        client.connectionpool.keepalive.minutes = 5
       }
     }
   }
@@ -132,9 +132,9 @@ The HTTP dispatcher uses an http client to post spans to a remote collector.
 
 ```
 a. url - url for the http span collector (eg: http://collector-svc:8080/spans)
-b. callTimeoutMillis - timeout in milliseconds for reporting spans to the collector. Defaults to 500 ms.
-b. connectionPool.maxIdleConnections - number of idle connections to keep in the connection pool. Defaults to 5
-b. connectionPool.keepAliveDurationMinutes - keep alive duration in minutes for connections in the connection pool. Defaults to 5.
+b. client.timeout.millis - timeout in milliseconds for reporting spans to the collector. Defaults to 500 ms.
+b. client.connectionpool.idle.max - number of idle connections to keep in the connection pool. Defaults to 5
+b. client.connectionpool.keepalive.minutes - keep alive duration in minutes for connections in the connection pool. Defaults to 5.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ agents {
       
       http {
         url = http://collector-svc:8080/spans
-        callTimeoutMillis = 500
-        connectionPool.maxIdleConnections = 5
-        connectionPool.keepAliveDurationMinutes = 5
+        client.timeoutmillis = 500
+        client.connectionpool.idleconnections.max = 5
+        client.connectionpool.keepaliveminutes = 5
       }
     }
   }

--- a/agent-dispatchers/http/pom.xml
+++ b/agent-dispatchers/http/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>haystack-agent-http-dispatcher</artifactId>
+
+    <parent>
+        <artifactId>haystack-agent-core</artifactId>
+        <groupId>com.expedia.www</groupId>
+        <version>0.1.7-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <okhttp.version>3.14.0</okhttp.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.expedia.www</groupId>
+            <artifactId>haystack-agent-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>
+                        <index>true</index>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                        <manifestEntries>
+                            <Application-Name>${project.name}</Application-Name>
+                            <Application-Version>${project.version}</Application-Version>
+                            <Implementation-Title>${project.name}</Implementation-Title>
+                            <Implementation-Vendor>Expedia</Implementation-Vendor>
+                            <Build-Jdk>${java.version}</Build-Jdk>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>${project.jdk.version}</source>
+                    <target>${project.jdk.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agent-dispatchers/http/src/main/java/com/expedia/www/haystack/agent/dispatcher/HttpDispatcher.java
+++ b/agent-dispatchers/http/src/main/java/com/expedia/www/haystack/agent/dispatcher/HttpDispatcher.java
@@ -39,13 +39,13 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 public class HttpDispatcher implements Dispatcher {
-    private final static Logger LOGGER = LoggerFactory.getLogger(HttpDispatcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpDispatcher.class);
 
     private static final MediaType PROTOBUF = MediaType.get("application/octet-stream");
-    private final static String URL = "url";
-    private final static String CALL_TIMEOUT_IN_MILLIS = "callTimeoutMillis";
-    private final static String MAX_IDLE_CONNECTIONS = "connectionPool.maxIdleConnections";
-    private final static String KEEP_ALIVE_DURATION_IN_MINUTES = "connectionPool.keepAliveDurationMinutes";
+    private static final String URL = "url";
+    private static final String CALL_TIMEOUT_IN_MILLIS = "client.timeoutmillis";
+    private static final String MAX_IDLE_CONNECTIONS = "client.connectionpool.idleconnections.max";
+    private static final String KEEP_ALIVE_DURATION_IN_MINUTES = "client.connectionpool.keepaliveminutes";
 
     Timer dispatchTimer;
     Meter dispatchFailure;
@@ -72,6 +72,7 @@ public class HttpDispatcher implements Dispatcher {
                 LOGGER.error("Fail to post the record to the http collector with status code {}", response.code());
             }
         } catch (Exception e) {
+            dispatchFailure.mark();
             LOGGER.error("Fail to post the record to the http collector", e);
         }
     }
@@ -92,7 +93,7 @@ public class HttpDispatcher implements Dispatcher {
     }
 
     private OkHttpClient buildClient(Config config) {
-        final int callTimeoutInMilliseconds = config.hasPath(CALL_TIMEOUT_IN_MILLIS) ? config.getInt(CALL_TIMEOUT_IN_MILLIS) : 500;
+        final int callTimeoutInMilliseconds = config.hasPath(CALL_TIMEOUT_IN_MILLIS) ? config.getInt(CALL_TIMEOUT_IN_MILLIS) : 1000;
         final int maxIdleConnections = config.hasPath(MAX_IDLE_CONNECTIONS) ? config.getInt(MAX_IDLE_CONNECTIONS) : 5;
         final int keepAliveDuration = config.hasPath(KEEP_ALIVE_DURATION_IN_MINUTES) ? config.getInt(KEEP_ALIVE_DURATION_IN_MINUTES) : 5;
 

--- a/agent-dispatchers/http/src/main/java/com/expedia/www/haystack/agent/dispatcher/HttpDispatcher.java
+++ b/agent-dispatchers/http/src/main/java/com/expedia/www/haystack/agent/dispatcher/HttpDispatcher.java
@@ -43,9 +43,9 @@ public class HttpDispatcher implements Dispatcher {
 
     private static final MediaType PROTOBUF = MediaType.get("application/octet-stream");
     private static final String URL = "url";
-    private static final String CALL_TIMEOUT_IN_MILLIS = "client.timeoutmillis";
-    private static final String MAX_IDLE_CONNECTIONS = "client.connectionpool.idleconnections.max";
-    private static final String KEEP_ALIVE_DURATION_IN_MINUTES = "client.connectionpool.keepaliveminutes";
+    private static final String CALL_TIMEOUT_IN_MILLIS = "client.timeout.millis";
+    private static final String MAX_IDLE_CONNECTIONS = "client.connectionpool.idle.max";
+    private static final String KEEP_ALIVE_DURATION_IN_MINUTES = "client.connectionpool.keepalive.minutes";
 
     Timer dispatchTimer;
     Meter dispatchFailure;

--- a/agent-dispatchers/http/src/main/java/com/expedia/www/haystack/agent/dispatcher/HttpDispatcher.java
+++ b/agent-dispatchers/http/src/main/java/com/expedia/www/haystack/agent/dispatcher/HttpDispatcher.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2017 Expedia, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.expedia.www.haystack.agent.dispatcher;
+
+import static com.expedia.www.haystack.agent.core.metrics.SharedMetricRegistry.buildMetricName;
+import static com.expedia.www.haystack.agent.core.metrics.SharedMetricRegistry.newMeter;
+import static com.expedia.www.haystack.agent.core.metrics.SharedMetricRegistry.newTimer;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
+import com.expedia.www.haystack.agent.core.Dispatcher;
+import com.typesafe.config.Config;
+import okhttp3.ConnectionPool;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+public class HttpDispatcher implements Dispatcher {
+    private final static Logger LOGGER = LoggerFactory.getLogger(HttpDispatcher.class);
+
+    private static final MediaType PROTOBUF = MediaType.get("application/octet-stream");
+    private final static String URL = "url";
+    private final static String CALL_TIMEOUT_IN_MILLIS = "callTimeoutMillis";
+    private final static String MAX_IDLE_CONNECTIONS = "connectionPool.maxIdleConnections";
+    private final static String KEEP_ALIVE_DURATION_IN_MINUTES = "connectionPool.keepAliveDurationMinutes";
+
+    Timer dispatchTimer;
+    Meter dispatchFailure;
+
+    OkHttpClient client;
+    String url;
+
+    @Override
+    public String getName() {
+        return "http";
+    }
+
+    @Override
+    public void dispatch(final byte[] ignored, final byte[] data) throws Exception {
+        RequestBody body = RequestBody.create(PROTOBUF, data);
+        Request request = new Request.Builder()
+                .url(url)
+                .post(body)
+                .build();
+
+        try (Timer.Context timer = dispatchTimer.time(); Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                dispatchFailure.mark();
+                LOGGER.error("Fail to post the record to the http collector with status code {}", response.code());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Fail to post the record to the http collector", e);
+        }
+    }
+
+    @Override
+    public void initialize(final Config config) {
+        final String agentName = config.hasPath("agentName") ? config.getString("agentName") : "";
+
+        Validate.notNull(config.getString(URL));
+        url = config.getString(URL);
+
+        client = buildClient(config);
+
+        dispatchTimer = newTimer(buildMetricName(agentName, "http.dispatch.timer"));
+        dispatchFailure = newMeter(buildMetricName(agentName, "http.dispatch.failure"));
+
+        LOGGER.info("Successfully initialized the http dispatcher with config={}", config);
+    }
+
+    private OkHttpClient buildClient(Config config) {
+        final int callTimeoutInMilliseconds = config.hasPath(CALL_TIMEOUT_IN_MILLIS) ? config.getInt(CALL_TIMEOUT_IN_MILLIS) : 500;
+        final int maxIdleConnections = config.hasPath(MAX_IDLE_CONNECTIONS) ? config.getInt(MAX_IDLE_CONNECTIONS) : 5;
+        final int keepAliveDuration = config.hasPath(KEEP_ALIVE_DURATION_IN_MINUTES) ? config.getInt(KEEP_ALIVE_DURATION_IN_MINUTES) : 5;
+
+        return new OkHttpClient.Builder()
+                .callTimeout(callTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
+                .connectionPool(new ConnectionPool(maxIdleConnections, keepAliveDuration, TimeUnit.SECONDS))
+                .build();
+    }
+
+    @Override
+    public void close() {
+        LOGGER.info("Closing the http dispatcher now...");
+    }
+}

--- a/agent-dispatchers/http/src/test/scala/com/expedia/www/haystack/agent/dispatcher/HttpDispatcherSpec.scala
+++ b/agent-dispatchers/http/src/test/scala/com/expedia/www/haystack/agent/dispatcher/HttpDispatcherSpec.scala
@@ -17,9 +17,10 @@
 
 package com.expedia.www.haystack.agent.dispatcher
 
-import com.codahale.metrics.Timer
+import com.codahale.metrics.{Meter, Timer}
+import com.expedia.open.tracing.Span
 import com.typesafe.config.ConfigFactory
-import okhttp3.{Call, OkHttpClient, Request}
+import okhttp3._
 import org.easymock.EasyMock
 import org.scalatest.mock.EasyMockSugar
 import org.scalatest.{FunSpec, Matchers}
@@ -31,16 +32,110 @@ class HttpDispatcherSpec extends FunSpec with Matchers with EasyMockSugar {
       val client = mock[OkHttpClient]
       val httpCall = mock[Call]
       val timer = mock[Timer]
+      val dispatchFailure = mock[Meter]
+      val responseBody = mock[ResponseBody]
+      val httpResponse = new Response.Builder()
+        .protocol(Protocol.HTTP_1_1)
+        .request(new Request.Builder()
+          .url("http://localhost:8080/span")
+          .build())
+        .code(200)
+        .body(responseBody)
+        .message("ok")
+        .build
       val timerContext = mock[Timer.Context]
 
       dispatcher.client = client
       dispatcher.url = "http://localhost:8080/span"
       dispatcher.dispatchTimer = timer
+      dispatcher.dispatchFailure = dispatchFailure
 
       val capturedRequest = EasyMock.newCapture[Request]()
+
+      httpCall.execute().andReturn(httpResponse)
+      timer.time().andReturn(timerContext)
+
       expecting {
         client.newCall(EasyMock.capture(capturedRequest)).andReturn(httpCall).once()
-        timer.time().andReturn(timerContext)
+        timerContext.close().once()
+      }
+
+      whenExecuting(client, httpCall, timer, dispatchFailure, timerContext) {
+        val span = Span.newBuilder().setTraceId("traceid").build()
+        dispatcher.dispatch(span.getTraceId.getBytes("utf-8"), span.toByteArray)
+        dispatcher.close()
+      }
+    }
+
+    it("should should record an error if the request was not successful") {
+      val dispatcher = new HttpDispatcher()
+      val client = mock[OkHttpClient]
+      val httpCall = mock[Call]
+      val timer = mock[Timer]
+      val dispatchFailure = mock[Meter]
+      val responseBody = mock[ResponseBody]
+      val httpResponse = new Response.Builder()
+        .protocol(Protocol.HTTP_1_1)
+        .request(new Request.Builder()
+          .url("http://localhost:8080/span")
+          .build())
+        .code(500) // error status code
+        .body(responseBody)
+        .message("not ok")
+        .build
+      val timerContext = mock[Timer.Context]
+
+      dispatcher.client = client
+      dispatcher.url = "http://localhost:8080/span"
+      dispatcher.dispatchTimer = timer
+      dispatcher.dispatchFailure = dispatchFailure
+
+      val capturedRequest = EasyMock.newCapture[Request]()
+
+      httpCall.execute().andReturn(httpResponse)
+      timer.time().andReturn(timerContext)
+
+      expecting {
+        client.newCall(EasyMock.capture(capturedRequest)).andReturn(httpCall).once()
+        timerContext.close().once()
+        dispatchFailure.mark().once()
+      }
+
+      whenExecuting(client, httpCall, timer, dispatchFailure, timerContext) {
+        val span = Span.newBuilder().setTraceId("traceid").build()
+        dispatcher.dispatch(span.getTraceId.getBytes("utf-8"), span.toByteArray)
+        dispatcher.close()
+      }
+    }
+
+    it("should should record an error if an exception is thrown") {
+      val dispatcher = new HttpDispatcher()
+      val client = mock[OkHttpClient]
+      val httpCall = mock[Call]
+      val timer = mock[Timer]
+      val dispatchFailure = mock[Meter]
+      val timerContext = mock[Timer.Context]
+
+      dispatcher.client = client
+      dispatcher.url = "http://localhost:8080/span"
+      dispatcher.dispatchTimer = timer
+      dispatcher.dispatchFailure = dispatchFailure
+
+      val capturedRequest = EasyMock.newCapture[Request]()
+
+      httpCall.execute().andStubThrow(new RuntimeException("error"))
+      timer.time().andReturn(timerContext)
+
+      expecting {
+        client.newCall(EasyMock.capture(capturedRequest)).andReturn(httpCall).once()
+        timerContext.close().once()
+        dispatchFailure.mark().once()
+      }
+
+      whenExecuting(client, httpCall, timer, dispatchFailure, timerContext) {
+        val span = Span.newBuilder().setTraceId("traceid").build()
+        dispatcher.dispatch(span.getTraceId.getBytes("utf-8"), span.toByteArray)
+        dispatcher.close()
       }
     }
 
@@ -50,6 +145,21 @@ class HttpDispatcherSpec extends FunSpec with Matchers with EasyMockSugar {
         dispatcher.initialize(ConfigFactory.empty())
       }
       caught.getMessage shouldEqual "No configuration setting found for key 'url'"
+    }
+
+    it("should set configs from input") {
+      val dispatcher = new HttpDispatcher()
+
+      val config = ConfigFactory.parseString(
+        """
+          | url: "http://test:8080"
+          | client.timeoutmillis: 123
+        """.stripMargin)
+
+      dispatcher.initialize(config)
+
+      dispatcher.url shouldBe "http://test:8080"
+      dispatcher.client.callTimeoutMillis() shouldBe 123
     }
   }
 }

--- a/agent-dispatchers/http/src/test/scala/com/expedia/www/haystack/agent/dispatcher/HttpDispatcherSpec.scala
+++ b/agent-dispatchers/http/src/test/scala/com/expedia/www/haystack/agent/dispatcher/HttpDispatcherSpec.scala
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2017 Expedia, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.expedia.www.haystack.agent.dispatcher
+
+import com.codahale.metrics.Timer
+import com.typesafe.config.ConfigFactory
+import okhttp3.{Call, OkHttpClient, Request}
+import org.easymock.EasyMock
+import org.scalatest.mock.EasyMockSugar
+import org.scalatest.{FunSpec, Matchers}
+
+class HttpDispatcherSpec extends FunSpec with Matchers with EasyMockSugar {
+  describe("Http Span Dispatcher") {
+    it("should dispatch span to http collector with success") {
+      val dispatcher = new HttpDispatcher()
+      val client = mock[OkHttpClient]
+      val httpCall = mock[Call]
+      val timer = mock[Timer]
+      val timerContext = mock[Timer.Context]
+
+      dispatcher.client = client
+      dispatcher.url = "http://localhost:8080/span"
+      dispatcher.dispatchTimer = timer
+
+      val capturedRequest = EasyMock.newCapture[Request]()
+      expecting {
+        client.newCall(EasyMock.capture(capturedRequest)).andReturn(httpCall).once()
+        timer.time().andReturn(timerContext)
+      }
+    }
+
+    it("should fail to initialize http dispatcher if url property isn't present") {
+      val dispatcher = new HttpDispatcher()
+      val caught = intercept[Exception] {
+        dispatcher.initialize(ConfigFactory.empty())
+      }
+      caught.getMessage shouldEqual "No configuration setting found for key 'url'"
+    }
+  }
+}

--- a/agent-dispatchers/http/src/test/scala/com/expedia/www/haystack/agent/dispatcher/HttpDispatcherSpec.scala
+++ b/agent-dispatchers/http/src/test/scala/com/expedia/www/haystack/agent/dispatcher/HttpDispatcherSpec.scala
@@ -153,7 +153,7 @@ class HttpDispatcherSpec extends FunSpec with Matchers with EasyMockSugar {
       val config = ConfigFactory.parseString(
         """
           | url: "http://test:8080"
-          | client.timeoutmillis: 123
+          | client.timeout.millis: 123
         """.stripMargin)
 
       dispatcher.initialize(config)

--- a/bundlers/haystack-agent/pom.xml
+++ b/bundlers/haystack-agent/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>haystack-agent-kinesis-dispatcher</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.expedia.www</groupId>
+            <artifactId>haystack-agent-http-dispatcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>agent-providers/span</module>
         <module>agent-dispatchers/kafka</module>
         <module>agent-dispatchers/kinesis</module>
+        <module>agent-dispatchers/http</module>
         <module>bundlers/haystack-agent</module>
     </modules>
 


### PR DESCRIPTION
Add http dispatcher to haystack agent.
From my personal experience is hard to expose Kafka services running inside Kuberneters clusters. Hopefully this will help folks who are not using Kinesis and want an easy way to submit spans from an agent.

Fixes #46 