### PR TITLE
chore: improves error message for when dispatchers are empty accordingly to the agent.

### DIFF
--- a/agent-providers/span/src/main/java/com/expedia/www/haystack/agent/core/BaseAgent.java
+++ b/agent-providers/span/src/main/java/com/expedia/www/haystack/agent/core/BaseAgent.java
@@ -4,6 +4,7 @@ import com.expedia.www.haystack.agent.core.config.ConfigurationHelpers;
 import com.expedia.www.haystack.agent.span.enricher.Enricher;
 import com.google.common.annotations.VisibleForTesting;
 import com.typesafe.config.Config;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 
@@ -48,7 +49,11 @@ public abstract class BaseAgent implements Agent {
                     });
         }
 
-        Validate.notEmpty(dispatchers, "Span agent dispatchers can't be an empty set");
+        Validate.notEmpty(
+                dispatchers,
+                "%s agent dispatchers can't be an empty set",
+                StringUtils.capitalize(getName())
+        );
 
         return dispatchers;
     }
@@ -61,7 +66,7 @@ public abstract class BaseAgent implements Agent {
                     .map(clazz -> {
                         try {
                             final Class c = Class.forName(clazz);
-                            logger.info("Initializing the span enricher with class name '{}'", clazz);
+                            logger.info("Initializing the {} enricher with class name '{}'", getName(), clazz);
                             return (Enricher) c.newInstance();
                         } catch (Exception e) {
                             logger.error("Fail to initialize the enricher with clazz name {}", clazz, e);

--- a/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/pitchfork/spi/PitchforkAgentSpec.scala
+++ b/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/pitchfork/spi/PitchforkAgentSpec.scala
@@ -16,7 +16,7 @@
  */
 
 
-package com.expedia.www.haystack.agent.span.spi
+package com.expedia.www.haystack.agent.pitchfork.spi
 
 import java.io.IOException
 import java.net.URL
@@ -28,23 +28,21 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.easymock.EasyMockSugar
 import org.scalatest.{FunSpec, Matchers}
 
-import scala.collection.JavaConversions._
-
 class DummyEnricher extends Enricher {
   override def apply(span: Span.Builder): Unit = ()
 }
 
-class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
+class PitchforkAgentSpec extends FunSpec with Matchers with EasyMockSugar {
 
   private val dispatcherLoadFile = "META-INF/services/com.expedia.www.haystack.agent.core.Dispatcher"
 
-  describe("Span Agent") {
-    it("should return the 'spans' as agent name") {
-      new SpanAgent().getName shouldEqual "spans"
+  describe("Pitchfork Agent") {
+    it("should return the 'pitchfork' as agent name") {
+      new PitchforkAgent().getName shouldEqual "pitchfork"
     }
 
     it("should load the dispatchers from the config") {
-      val agent = new SpanAgent()
+      val agent = new PitchforkAgent()
       val cfg = ConfigFactory.parseString(
         """
           |    k1 = "v1"
@@ -60,11 +58,11 @@ class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
       val cl = new ReplacingClassLoader(getClass.getClassLoader, dispatcherLoadFile, "dispatcherProvider.txt")
       val dispatchers = agent.loadAndInitializeDispatchers(cfg, cl, "spans")
       dispatchers.size() shouldBe 1
-      dispatchers.head.close()
+      dispatchers.get(0).close()
     }
 
     it("initialization should fail if no dispatchers exist") {
-      val agent = new SpanAgent()
+      val agent = new PitchforkAgent()
       val cfg = ConfigFactory.parseString(
         """
           |    k1 = "v1"
@@ -81,11 +79,11 @@ class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
         agent.loadAndInitializeDispatchers(cfg, getClass.getClassLoader, "spans")
       }
 
-      caught.getMessage shouldEqual "Spans agent dispatchers can't be an empty set"
+      caught.getMessage shouldEqual "Pitchfork agent dispatchers can't be an empty set"
     }
 
     it ("should load enrichers") {
-      val agent = new SpanAgent()
+      val agent = new PitchforkAgent()
       val cfg = ConfigFactory.parseString(
         """
           |    k1 = "v1"
@@ -96,7 +94,7 @@ class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
           |    ]
         """.stripMargin)
       val enrichers = agent.loadSpanEnrichers(cfg)
-      enrichers.length shouldBe 1
+      enrichers.size() shouldBe 1
     }
   }
 


### PR DESCRIPTION
This PR improves the error messages from the agent telling the user whether the problem was in Spans Agent or Pitchfork Agent.

Ping @keshavpeswani @worldtiki 