### PR TITLE
fix: relax the defaults to simpler ones and also fixes the inclusion of the logger dispatcher (#80).

### DIFF
--- a/agent-providers/span/src/main/java/com/expedia/www/haystack/agent/core/BaseAgent.java
+++ b/agent-providers/span/src/main/java/com/expedia/www/haystack/agent/core/BaseAgent.java
@@ -35,7 +35,6 @@ public abstract class BaseAgent implements Agent {
     public List<Dispatcher> loadAndInitializeDispatchers(final Config config, ClassLoader cl, String agentName) {
         final List<Dispatcher> dispatchers = new ArrayList<>();
         final ServiceLoader<Dispatcher> loadedDispatchers = ServiceLoader.load(Dispatcher.class, cl);
-
         for (final Dispatcher dispatcher : loadedDispatchers) {
             final Map<String, Config> dispatches = ConfigurationHelpers.readDispatchersConfig(config, agentName);
             dispatches

--- a/agent-providers/span/src/test/resources/dispatcherProvider.txt
+++ b/agent-providers/span/src/test/resources/dispatcherProvider.txt
@@ -1,1 +1,2 @@
 com.expedia.www.haystack.agent.span.helpers.TestDispatcher
+com.expedia.www.haystack.agent.span.helpers.TestDispatcherEmptyConfig

--- a/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/helpers/TestDispatcherEmptyConfig.scala
+++ b/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/helpers/TestDispatcherEmptyConfig.scala
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2017 Expedia, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+
+package com.expedia.www.haystack.agent.span.helpers
+
+import com.expedia.www.haystack.agent.core.Dispatcher
+import com.typesafe.config.Config
+
+class TestDispatcherEmptyConfig extends Dispatcher {
+
+  private var isInitialized = false
+
+  /**
+    * returns the unique name for this dispatcher
+    *
+    * @return
+    */
+  override def getName: String = "test-dispatcher-empty-config"
+
+  /**
+    * dispatch the record to the sink
+    *
+    * @param partitionKey partitionKey if present, else send null
+    * @param data         data bytes that need to be dispatched to the sink
+    * @throws Exception throws exception if fails to dispatch
+    */
+  override def dispatch(partitionKey: Array[Byte], data: Array[Byte]) = ()
+
+  /**
+    * initializes the dispatcher for pushing span records to the sink
+    *
+    * @param conf
+    */
+  override def initialize(conf: Config): Unit = {
+    isInitialized = true
+  }
+
+  /**
+    * close the dispatcher, this is called when the agent is shutting down.
+    */
+  override def close(): Unit = {
+    assert(isInitialized, "Fail to close as the dispatcher isn't initialized yet")
+  }
+}

--- a/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/spi/SpanAgentSpec.scala
+++ b/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/spi/SpanAgentSpec.scala
@@ -54,12 +54,14 @@ class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
           |      test-dispatcher {
           |        queueName = "myqueue"
           |      }
+          |      test-dispatcher-empty-config {
+          |      }
           |    }
         """.stripMargin)
 
       val cl = new ReplacingClassLoader(getClass.getClassLoader, dispatcherLoadFile, "dispatcherProvider.txt")
       val dispatchers = agent.loadAndInitializeDispatchers(cfg, cl, "spans")
-      dispatchers.size() shouldBe 1
+      dispatchers.size() shouldBe 2
       dispatchers.head.close()
     }
 

--- a/api/src/main/java/com/expedia/www/haystack/agent/core/config/ConfigurationHelpers.java
+++ b/api/src/main/java/com/expedia/www/haystack/agent/core/config/ConfigurationHelpers.java
@@ -93,7 +93,7 @@ public class ConfigurationHelpers {
         final Map<String, Config> dispatchersConfigMap = new HashMap<>();
 
         final Set<String> dispatcherNames = new HashSet<>();
-        dispatchers.entrySet().forEach((e) -> dispatcherNames.add(findRootKeyName(e.getKey())));
+        dispatchers.root().keySet().forEach((e) -> dispatcherNames.add(findRootKeyName(e)));
 
         dispatcherNames.forEach((name) -> dispatchersConfigMap.put(name, addAgentNameToConfig(dispatchers.getConfig(name), agentName)));
         return dispatchersConfigMap;

--- a/bundlers/haystack-agent/pom.xml
+++ b/bundlers/haystack-agent/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>com.expedia.www</groupId>
+            <artifactId>haystack-agent-logger-dispatcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.expedia.www</groupId>
             <artifactId>blobs-agent-dispatchers</artifactId>
             <version>${blobs.version}</version>
         </dependency>

--- a/bundlers/haystack-agent/src/main/resources/logback.xml
+++ b/bundlers/haystack-agent/src/main/resources/logback.xml
@@ -1,7 +1,5 @@
 <configuration>
-    <logger name="com.expedia.www.haystack.agent.dispatcher.LoggerDispatcher" level="DEBUG">
-        <appender-ref ref="STDOUT-LOGGER_DISPATCHER" />
-    </logger>
+    <logger name="com.expedia.www.haystack.agent.dispatcher.LoggerDispatcher" level="DEBUG" />
 
     <jmxConfigurator />
 
@@ -15,14 +13,6 @@
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
                 %d{yyyy-MM-dd HH:mm:ss:SSS} %thread, %level, %logger{70}, "%msg"%n
-            </Pattern>
-        </layout>
-    </appender>
-
-    <appender name="STDOUT-LOGGER_DISPATCHER" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>
-                %d{yyyy-MM-dd HH:mm:ss:SSS} "%msg"%n
             </Pattern>
         </layout>
     </appender>

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -3,52 +3,8 @@ agents {
     enabled = true
     port = 35000
     dispatchers {
-      kafka {
-        bootstrap.servers = "kafkasvc:9092"
-        producer.topic = "proto-spans"
-        buffer.memory = 1048576
-        retries = 2
-      }
-    }
-  }
-  ossblobs {
-    enabled = false
-    port = 35001
-    max.blob.size.in.kb = 512
-    dispatchers {
-      s3 {
-        keep.alive = true
-        max.outstanding.requests = 150
-        should.wait.for.upload = false
-        max.connections = 50
-        retry.count = 1
-        bucket.name = "haystack-blobs"
-        region = "us-east-1"
-        aws.access.key = "accessKey"
-        aws.secret.key = "secretKey"
-      }
-    }
-  }
+      logger {
 
-  pitchfork {
-    enabled = false
-    port = 9411
-    http.threads {
-       max = 16
-       min = 2
-    }
-    gzip.enabled = true
-    idle.timeout.ms = 60000
-    stop.timeout.ms = 30000
-    accept.null.timestamps = false
-    max.timestamp.drift.sec = -1
-    
-    dispatchers {
-      kafka {
-        bootstrap.servers = "kafkasvc:9092"
-        producer.topic = "proto-spans"
-        buffer.memory = 1048576
-        retries = 2
       }
     }
   }


### PR DESCRIPTION
This PR does two things:

1. Fixes the inclusion of the `logger` dispatcher in the agent and makes sure its config is correctly parsed as it is an empty object (https://github.com/ExpediaDotCom/haystack-agent/pull/83/files#diff-f245def29ce308595ff682915bb60c7fR96)
2. Relax the defaults, using logger.

Closes #80

Ping @keshavpeswani @ashishagg @worldtiki 