### PR TITLE
tests: changes the name of a dispatcher in test for better readability

### DIFF
--- a/agent-providers/span/src/test/resources/dispatcherProvider.txt
+++ b/agent-providers/span/src/test/resources/dispatcherProvider.txt
@@ -1,2 +1,3 @@
 com.expedia.www.haystack.agent.span.helpers.TestDispatcher
+com.expedia.www.haystack.agent.span.helpers.TestDispatcher2
 com.expedia.www.haystack.agent.span.helpers.TestDispatcherEmptyConfig

--- a/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/helpers/TestDispatcher2.scala
+++ b/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/helpers/TestDispatcher2.scala
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2017 Expedia, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+
+package com.expedia.www.haystack.agent.span.helpers
+
+import com.expedia.www.haystack.agent.core.Dispatcher
+import com.typesafe.config.Config
+
+class TestDispatcher2 extends Dispatcher {
+
+  private var isInitialized = false
+
+  /**
+    * returns the unique name for this dispatcher
+    *
+    * @return
+    */
+  override def getName: String = "test-dispatcher-2"
+
+  /**
+    * dispatch the record to the sink
+    *
+    * @param partitionKey partitionKey if present, else send null
+    * @param data         data bytes that need to be dispatched to the sink
+    * @throws Exception throws exception if fails to dispatch
+    */
+  override def dispatch(partitionKey: Array[Byte], data: Array[Byte]) = ()
+
+  /**
+    * initializes the dispatcher for pushing span records to the sink
+    *
+    * @param conf
+    */
+  override def initialize(conf: Config): Unit = {
+    isInitialized = true
+    assert(conf != null && conf.getString("queueName") == "myqueue")
+  }
+
+  /**
+    * close the dispatcher, this is called when the agent is shutting down.
+    */
+  override def close(): Unit = {
+    assert(isInitialized, "Fail to close as the dispatcher isn't initialized yet")
+  }
+}

--- a/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/spi/SpanAgentSpec.scala
+++ b/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/spi/SpanAgentSpec.scala
@@ -77,7 +77,7 @@ class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
           |      test-dispatcher {
           |        queueName = "myqueue"
           |      }
-          |      test-dispatcher-empty-config {
+          |      test-dispatcher-2 {
           |         enabled = false
           |      }
           |    }

--- a/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/spi/SpanAgentSpec.scala
+++ b/agent-providers/span/src/test/scala/com/expedia/www/haystack/agent/span/spi/SpanAgentSpec.scala
@@ -66,6 +66,30 @@ class SpanAgentSpec extends FunSpec with Matchers with EasyMockSugar {
       dispatchers.foreach(_.close())
     }
 
+    it("should not load an unknown dispatcher") {
+      val agent = new SpanAgent()
+      val cfg = ConfigFactory.parseString(
+        """
+          |    k1 = "v1"
+          |    port = 8080
+          |
+          |    dispatchers {
+          |      test-dispatcher {
+          |        queueName = "myqueue"
+          |      }
+          |      test-dispatcher-3 {
+          |         enabled = false
+          |      }
+          |    }
+        """.stripMargin)
+
+      val cl = new ReplacingClassLoader(getClass.getClassLoader, dispatcherLoadFile, "dispatcherProvider.txt")
+      val dispatchers = agent.loadAndInitializeDispatchers(cfg, cl, "spans")
+      dispatchers.size() shouldBe 1
+      dispatchers.head.getName shouldBe "test-dispatcher"
+      dispatchers.foreach(_.close())
+    }
+
     it("should not load a 'disabled' dispatcher") {
       val agent = new SpanAgent()
       val cfg = ConfigFactory.parseString(


### PR DESCRIPTION
test-dispatcher-empty-config is a misleading name given that we are actually passing a config: enabled = false

The intention of the test including `test-dispatcher-empty-config` (which probably have been copied) was that we can actually parse a dispatcher with empty body config.

Ping @keshavpeswani @ashishagg 